### PR TITLE
Set up Github action to have main sync to render-prod

### DIFF
--- a/.github/workflows/sync-render-branch.yml
+++ b/.github/workflows/sync-render-branch.yml
@@ -1,0 +1,28 @@
+name: Syncs main to render branch
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  sync-render-branch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Force-updates render branch from main
+        run: |
+          git push origin HEAD:render-prod --force


### PR DESCRIPTION
Made a Github action so when someone pushes to ```main```, it automatically gets pushed to ```render-prod``` branch to pick up new changes. This branch is what is deployed by Render.

Test that it works upon workflow running successfully on push (when merged to main). Will check workflow under 'Actions' tab.